### PR TITLE
WIP: grab csrf_token from /messaging page and save XSRF cookies

### DIFF
--- a/pytextnow/login.py
+++ b/pytextnow/login.py
@@ -4,5 +4,7 @@ def login():
     print("\n")
     print("Open application tab and copy connect.sid cookie and paste it here.")
     sid = input("connect.sid: ")
+    print("Open application tab and copy _csrf cookie and paste it here.")
+    csrf = input("_csrf")
 
-    return sid
+    return sid, csrf


### PR DESCRIPTION
When I was testing, I was able to send multiple SMS messages. I didn't make any changes to the MMS code. We'll probably need to save those XSRF cookies, too.