### PR TITLE
fixed bug with login.py file

### DIFF
--- a/pytextnow/TNAPI.py
+++ b/pytextnow/TNAPI.py
@@ -61,7 +61,7 @@ class Client:
                 with open(self._user_cookies_file, "w") as file:
                     file.write(json.dumps(self._user_cookies))
         else:
-            sid,csrf = sid_cookie,csrf_cookie if sid_cookie and csrf_cookie else login()
+            sid,csrf = (sid_cookie,csrf_cookie) if sid_cookie and csrf_cookie else login()
             self.cookies = {
                 'connect.sid': sid,
                 '_csrf': csrf,

--- a/pytextnow/login.py
+++ b/pytextnow/login.py
@@ -5,6 +5,6 @@ def login():
     print("Open application tab and copy connect.sid cookie and paste it here.")
     sid = input("connect.sid: ")
     print("Open application tab and copy _csrf cookie and paste it here.")
-    csrf = input("_csrf")
+    csrf = input("_csrf: ")
 
     return sid, csrf


### PR DESCRIPTION
I noticed that when user_cookies.json was populated by login.py, it would put both the `sid_cookie` and the `csrf_cookie` in the `csrf` field as a list with `sid` set to null. Adding parentheses fixed the problem. I also cleaned up the _csrf `input` call